### PR TITLE
feat: add input components and pay form

### DIFF
--- a/src/app/p/[projectId]/components/PayForm.tsx
+++ b/src/app/p/[projectId]/components/PayForm.tsx
@@ -4,11 +4,17 @@ import { useAccount } from "wagmi";
 import { useNativeTokenSymbol } from "../hooks/useNativeTokenSymbol";
 import { useJBTerminalContext, useJbMultiTerminalPay } from "juice-sdk-react";
 import { NATIVE_TOKEN } from "juice-sdk-core";
+import DecimalsInput from "@/components/ui/decimalsInput";
+import { useState } from "react";
 
 export function PayForm({ projectId }: { projectId: bigint }) {
+  const [value, setValue] = useState("0.069");
+
   const { address: terminalAddress } = useJBTerminalContext();
   const nativeTokenSymbol = useNativeTokenSymbol();
   const { address } = useAccount();
+  
+  const decimals = 18;
 
   /**
    *    uint256 projectId,
@@ -19,16 +25,15 @@ export function PayForm({ projectId }: { projectId: bigint }) {
         string calldata memo,
         bytes calldata metadata
    */
-  const value = parseUnits("0.069", 18);
 
   const args = address
     ? [
         projectId,
         NATIVE_TOKEN,
-        value,
+        value ? parseUnits(value, decimals) : 0n,
         address,
         0n,
-        "payed on juicescan.io",
+        "paid on juicescan.io",
         "0x0",
       ]
     : undefined;
@@ -41,20 +46,21 @@ export function PayForm({ projectId }: { projectId: bigint }) {
       ? [
           projectId,
           NATIVE_TOKEN,
-          value,
+          value ? parseUnits(value, decimals) : 0n,
           address,
           0n,
-          "payed on juicescan.io",
+          "paid on juicescan.io",
           "0x0",
         ]
       : undefined,
-    value,
+    value: value ? parseUnits(value, decimals) : 0n,
   });
 
   return (
-    <div>
+    <div className="flex flex-col gap-2">
+      <DecimalsInput value={value} onChange={setValue} size="lg"/>
       <Button size="lg" className="w-full" onClick={() => write?.()}>
-        Pay 0.069 {nativeTokenSymbol}
+        Pay {value ? value : "0"} {nativeTokenSymbol}
       </Button>
     </div>
   );

--- a/src/app/p/[projectId]/components/PayForm.tsx
+++ b/src/app/p/[projectId]/components/PayForm.tsx
@@ -8,7 +8,7 @@ import DecimalsInput from "@/components/ui/decimalsInput";
 import { useState } from "react";
 
 export function PayForm({ projectId }: { projectId: bigint }) {
-  const [value, setValue] = useState("0.069");
+  const [value, setValue] = useState("0");
 
   const { address: terminalAddress } = useJBTerminalContext();
   const nativeTokenSymbol = useNativeTokenSymbol();

--- a/src/components/ui/decimalsInput.tsx
+++ b/src/components/ui/decimalsInput.tsx
@@ -7,25 +7,36 @@ interface DecimalsInputProps extends Omit<InputProps, "onChange" | "value"> {
   decimals?: number; // Decimal limit, defaults to 18
 }
 
-const DecimalsInput: React.FC<DecimalsInputProps> = ({ value, onChange, decimals = 18, ...props }) => {
+const DecimalsInput: React.FC<DecimalsInputProps> = ({
+  value,
+  onChange,
+  decimals = 18,
+  ...props
+}) => {
+  const [warning, setWarning] = React.useState(false);
   const decimalsRegex = new RegExp(`^\\d*\\.?\\d{0,${decimals}}$`);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = event.target.value;
     if (newValue === "" || decimalsRegex.test(newValue)) {
       onChange(newValue);
+      setWarning(false);
     } else {
       console.error("Rejected invalid input: ", newValue);
+      setWarning(true);
     }
   };
 
   return (
-    <Input
-      {...props}
-      value={value}
-      onChange={handleChange}
-      type="text"
-    />
+    <>
+      <Input {...props} value={value} onChange={handleChange} type="text" />
+      {warning && (
+        <p className="text-red-500 text-sm">
+          This input only accepts numbers (with up to {decimals} decimal
+          places).
+        </p>
+      )}
+    </>
   );
 };
 

--- a/src/components/ui/decimalsInput.tsx
+++ b/src/components/ui/decimalsInput.tsx
@@ -8,14 +8,12 @@ interface DecimalsInputProps extends Omit<InputProps, "onChange" | "value"> {
 }
 
 const DecimalsInput: React.FC<DecimalsInputProps> = ({ value, onChange, decimals = 18, ...props }) => {
-  const decimalRegex = new RegExp(`^-?\\d*\\.?\\d{0,${decimals}}$`);
+  const decimalsRegex = new RegExp(`^\\d*\\.?\\d{0,${decimals}}$`);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = event.target.value;
-    if (decimalRegex.test(newValue)) {
+    if (newValue === "" || decimalsRegex.test(newValue)) {
       onChange(newValue);
-    } else if (newValue === "") {
-      onChange("0");      
     } else {
       console.error("Rejected invalid input: ", newValue);
     }

--- a/src/components/ui/decimalsInput.tsx
+++ b/src/components/ui/decimalsInput.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+import { Input, InputProps } from "./input";
+
+interface DecimalsInputProps extends Omit<InputProps, "onChange" | "value"> {
+  value: string;
+  onChange: (value: string) => void;
+  decimals?: number; // Decimal limit, defaults to 18
+}
+
+const DecimalsInput: React.FC<DecimalsInputProps> = ({ value, onChange, decimals = 18, ...props }) => {
+  const decimalRegex = new RegExp(`^-?\\d*\\.?\\d{0,${decimals}}$`);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = event.target.value;
+    if (decimalRegex.test(newValue)) {
+      onChange(newValue);
+    } else if (newValue === "") {
+      onChange("0");      
+    } else {
+      console.error("Rejected invalid input: ", newValue);
+    }
+  };
+
+  return (
+    <Input
+      {...props}
+      value={value}
+      onChange={handleChange}
+      type="text"
+    />
+  );
+};
+
+export default DecimalsInput;

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const inputVariants = cva(
+  "shadow-sm focus:ring-zinc-500 focus:border-zinc-500 block w-full sm:text-sm border-gray-300 rounded-md",
+  {
+    variants: {
+      variant: {
+        // Leaving room for more variants later on.
+        default: "border border-zinc-800 bg-gray-100 text-zinc-800",
+      },
+      size: {
+        default: "py-2 px-3",
+        sm: "py-1 px-2 text-sm",
+        lg: "py-3 px-4 text-lg",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+export interface InputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size">,
+    VariantProps<typeof inputVariants> {
+  asChild?: boolean;
+}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "input";
+    return (
+      <Comp
+        className={cn(inputVariants({ variant, size }), className)}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = "Input";
+
+export { Input, inputVariants };


### PR DESCRIPTION
![image](https://github.com/Bananapus/juicescan/assets/96905094/44c25f0a-0d8c-4d0e-a79f-a64064e44abd)

Make the pay input dynamic! I also added a utility component called `DecimalsInput`. You specify a number of decimals (default 18) and it will only let the user input valid numbers up to that number of decimals. It's a string input, meaning it can go beyond JS-friendly floats.

If the user attempts to input a non-valid character, it just doesn't go through.

QUESTION: should it accept negative numbers? It did at first but I removed this.